### PR TITLE
Add pretrained MobileViT model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# test
+# Real-time Facial Expression Recognition Demo
+
+This project provides a lightweight demo of real-time facial expression recognition using a MobileViT Transformer model.
+
+## Features
+
+- Capture frames from the webcam
+- Detect faces using OpenCV Haar cascades
+- Recognize seven basic emotions with a MobileViT Transformer
+- Display results with bounding boxes and scores
+
+## Requirements
+
+- Python 3.8+
+- PyTorch
+- timm
+- OpenCV (`opencv-python`)
+- NumPy
+
+Install dependencies with:
+
+```bash
+pip install torch opencv-python numpy timm
+```
+
+## Running
+
+```bash
+python app.py
+```
+
+Press `q` to quit the application.
+
+Pretrained weights greatly improve recognition accuracy. Download a MobileViT emotion recognition checkpoint and place it at `weights/emotion_vit.pth`. If the file is missing, the demo will fall back to random weights and results will be poor.
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,36 @@
+import cv2
+import torch
+import numpy as np
+from face_detector import FaceDetector
+from emotion_recognizer import EmotionRecognizer
+
+
+def main():
+    detector = FaceDetector()
+    recognizer = EmotionRecognizer()
+    cap = cv2.VideoCapture(0)
+    if not cap.isOpened():
+        print("Unable to access camera")
+        return
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        faces = detector.detect(frame)
+        for (x, y, w, h) in faces:
+            face_img = frame[y:y+h, x:x+w]
+            label, score = recognizer.predict(face_img)
+            cv2.rectangle(frame, (x, y), (x+w, y+h), (0, 255, 0), 2)
+            text = f"{label} {score:.2f}"
+            cv2.putText(frame, text, (x, y-10), cv2.FONT_HERSHEY_SIMPLEX, 0.9, (255, 0, 0), 2)
+        cv2.imshow('Emotion Recognition', frame)
+        if cv2.waitKey(1) & 0xFF == ord('q'):
+            break
+
+    cap.release()
+    cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    main()

--- a/emotion_recognizer.py
+++ b/emotion_recognizer.py
@@ -1,0 +1,32 @@
+import os
+import cv2
+import torch
+import numpy as np
+from model import load_model
+
+
+LABELS = ["angry", "disgust", "fear", "happy", "sad", "surprise", "neutral"]
+
+
+class EmotionRecognizer:
+    def __init__(self, weight_path="weights/emotion_vit.pth", device=None):
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.model = load_model(weight_path, self.device)
+        self.softmax = torch.nn.Softmax(dim=1)
+
+    def preprocess(self, img):
+        img = cv2.resize(img, (224, 224))
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        img = img / 255.0
+        img = (img - 0.5) / 0.5
+        tensor = torch.tensor(img.transpose(2, 0, 1), dtype=torch.float32).unsqueeze(0)
+        return tensor.to(self.device)
+
+    def predict(self, img):
+        tensor = self.preprocess(img)
+        with torch.no_grad():
+            logits = self.model(tensor)
+            probs = self.softmax(logits)
+            score, idx = torch.max(probs, dim=1)
+        label = LABELS[idx.item()]
+        return label, score.item()

--- a/face_detector.py
+++ b/face_detector.py
@@ -1,0 +1,12 @@
+import cv2
+
+
+class FaceDetector:
+    def __init__(self):
+        # Use OpenCV's built-in Haar cascade
+        self.detector = cv2.CascadeClassifier(cv2.data.haarcascades + 'haarcascade_frontalface_default.xml')
+
+    def detect(self, frame):
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        faces = self.detector.detectMultiScale(gray, scaleFactor=1.1, minNeighbors=5)
+        return faces

--- a/model.py
+++ b/model.py
@@ -1,0 +1,23 @@
+"""Model utilities using a lightweight MobileViT architecture."""
+
+import os
+import torch
+from timm import create_model
+
+
+def load_model(weight_path="weights/emotion_vit.pth", device="cpu"):
+    """Load MobileViT with optional pretrained weights."""
+
+    model = create_model("mobilevit_xxs", pretrained=False, num_classes=7)
+
+    if weight_path and os.path.exists(weight_path):
+        state = torch.load(weight_path, map_location=device)
+        model.load_state_dict(state)
+    else:
+        print(
+            "WARNING: Weight file not found. Download pretrained weights for better accuracy."
+        )
+
+    model.to(device)
+    model.eval()
+    return model


### PR DESCRIPTION
## Summary
- switch model loader to use MobileViT from `timm`
- update emotion recognizer for new resolution and automatic device choice
- document weight download and additional dependency
- include `weights/` directory placeholder

## Testing
- `python -m py_compile app.py face_detector.py emotion_recognizer.py model.py`


------
https://chatgpt.com/codex/tasks/task_e_684ce8977d7883269ca9e23440615fb1