### PR TITLE
Update default weight handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ python app.py
 
 Press `q` to quit the application.
 
-The model weights can be provided via `model.pth` in the project directory. If no weights are found, the model runs with random initialization (for demonstration purposes only).
+Place the model weights as `emotion_vit.pth` inside a `weights/` folder located next to the code. If no weights are found, the model runs with random initialization (for demonstration purposes only).
 

--- a/model.py
+++ b/model.py
@@ -1,3 +1,4 @@
+import os
 import torch
 from torch import nn
 
@@ -24,8 +25,12 @@ class SimpleViT(nn.Module):
 
 
 def load_model(weight_path=None, device='cpu'):
+    """Load model weights with an optional custom path."""
+    if weight_path is None:
+        weight_path = os.path.join(os.path.dirname(__file__), "weights", "emotion_vit.pth")
+
     model = SimpleViT()
-    if weight_path:
+    if os.path.exists(weight_path):
         model.load_state_dict(torch.load(weight_path, map_location=device))
     model.to(device)
     model.eval()


### PR DESCRIPTION
## Summary
- compute default weight path in `load_model`
- document weight location

## Testing
- `python -m py_compile emotion_recognizer.py model.py`

------
https://chatgpt.com/codex/tasks/task_e_684cfd7f32708326bc7172a44d2153e7