### PR TITLE
Improve recognition accuracy with pretrained backbone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# test
+# Real-time Facial Expression Recognition Demo
+
+This project provides a lightweight demo of real-time facial expression recognition using a MobileViT Transformer model.
+
+## Features
+
+- Capture frames from the webcam
+- Detect faces using OpenCV Haar cascades
+- Recognize seven basic emotions with a MobileViT Transformer
+- Display results with bounding boxes and scores
+- Smooth predictions over several frames to reduce flicker
+
+## Requirements
+
+- Python 3.8+
+- PyTorch
+ - timm
+- tqdm
+- OpenCV (`opencv-python`)
+- NumPy
+- Matplotlib
+
+Install dependencies with:
+
+```bash
+pip install torch opencv-python numpy timm tqdm matplotlib
+```
+
+## Running
+
+```bash
+python app.py
+```
+
+Press `q` to quit the application.
+
+Pretrained weights greatly improve recognition accuracy. Download a MobileViT emotion recognition checkpoint and place it at `weights/emotion_vit.pth`. If the file is missing, the model will start from ImageNet pretrained weights, which work reasonably but are less accurate for emotion recognition.
+
+
+## Training on FER2013
+
+The repository expects the FER2013 dataset to be placed in a folder named
+`fer2013/` containing `train.csv` and `val.csv` files. After installing the
+requirements you can train the MobileViT model using:
+
+```bash
+python train.py
+```
+
+Training outputs a weight file at `weights/emotion_vit.pth` which will be
+used automatically by the demo.
+
+The training pipeline now applies additional augmentation (random rotation and
+color jitter) and uses the correct FER2013 label ordering. It runs for up to
+30 epochs with early stopping if the validation loss does not improve for three
+epochs. A learning rate scheduler automatically reduces the learning rate when
+progress stalls.
+After training finishes, the script displays plots showing the loss and
+accuracy curves for both the training and validation sets.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,37 @@
+import cv2
+import torch
+import numpy as np
+from face_detector import FaceDetector
+from emotion_recognizer import EmotionRecognizer
+
+
+def main():
+    detector = FaceDetector()
+    # Use a short history of predictions to smooth out noise between frames
+    recognizer = EmotionRecognizer(smooth_window=5)
+    cap = cv2.VideoCapture(0)
+    if not cap.isOpened():
+        print("Unable to access camera")
+        return
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        faces = detector.detect(frame)
+        for (x, y, w, h) in faces:
+            face_img = frame[y:y+h, x:x+w]
+            label, score = recognizer.predict(face_img)
+            cv2.rectangle(frame, (x, y), (x+w, y+h), (0, 255, 0), 2)
+            text = f"{label} {score:.2f}"
+            cv2.putText(frame, text, (x, y-10), cv2.FONT_HERSHEY_SIMPLEX, 0.9, (255, 0, 0), 2)
+        cv2.imshow('Emotion Recognition', frame)
+        if cv2.waitKey(1) & 0xFF == ord('q'):
+            break
+
+    cap.release()
+    cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    main()

--- a/emotion_recognizer.py
+++ b/emotion_recognizer.py
@@ -1,0 +1,38 @@
+import os
+import cv2
+import torch
+import numpy as np
+from collections import deque
+from model import load_model
+
+
+LABELS = ["angry", "disgust", "fear", "happy", "sad", "surprise", "neutral"]
+
+
+class EmotionRecognizer:
+    def __init__(self, weight_path="weights/emotion_vit.pth", device=None, smooth_window=5):
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.model = load_model(weight_path, self.device)
+        self.softmax = torch.nn.Softmax(dim=1)
+        # Keep a window of recent probability vectors to smooth predictions
+        self.history = deque(maxlen=smooth_window)
+
+    def preprocess(self, img):
+        img = cv2.resize(img, (224, 224))
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        img = img / 255.0
+        img = (img - 0.5) / 0.5
+        tensor = torch.tensor(img.transpose(2, 0, 1), dtype=torch.float32).unsqueeze(0)
+        return tensor.to(self.device)
+
+    def predict(self, img):
+        tensor = self.preprocess(img)
+        with torch.no_grad():
+            logits = self.model(tensor)
+            probs = self.softmax(logits)
+        # accumulate probabilities for smoothing
+        self.history.append(probs.squeeze(0))
+        avg_prob = torch.stack(list(self.history), dim=0).mean(dim=0)
+        score, idx = torch.max(avg_prob, dim=0)
+        label = LABELS[idx.item()]
+        return label, score.item()

--- a/face_detector.py
+++ b/face_detector.py
@@ -1,0 +1,12 @@
+import cv2
+
+
+class FaceDetector:
+    def __init__(self):
+        # Use OpenCV's built-in Haar cascade
+        self.detector = cv2.CascadeClassifier(cv2.data.haarcascades + 'haarcascade_frontalface_default.xml')
+
+    def detect(self, frame):
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        faces = self.detector.detectMultiScale(gray, scaleFactor=1.1, minNeighbors=5)
+        return faces

--- a/model.py
+++ b/model.py
@@ -1,0 +1,25 @@
+"""Model utilities using a lightweight MobileViT architecture."""
+
+import os
+import torch
+from timm import create_model
+
+
+def load_model(weight_path="weights/emotion_vit.pth", device="cpu"):
+    """Load MobileViT with pretrained ImageNet weights if emotion weights are missing."""
+
+    # Start from ImageNet pretrained weights for better accuracy when custom
+    # emotion weights are unavailable.
+    model = create_model("mobilevit_xxs", pretrained=True, num_classes=7)
+
+    if weight_path and os.path.exists(weight_path):
+        state = torch.load(weight_path, map_location=device)
+        model.load_state_dict(state)
+    else:
+        print(
+            "WARNING: Weight file not found. Download pretrained weights for better accuracy."
+        )
+
+    model.to(device)
+    model.eval()
+    return model

--- a/train.py
+++ b/train.py
@@ -1,0 +1,145 @@
+import os
+import pandas as pd
+import numpy as np
+from PIL import Image
+import torch
+from torch.utils.data import Dataset, DataLoader
+from torchvision import transforms
+from timm import create_model
+from tqdm import tqdm
+import matplotlib.pyplot as plt
+
+
+class FER2013Dataset(Dataset):
+    """Dataset loader for FER2013 CSV files."""
+
+    def __init__(self, csv_path, label_map=None, transform=None):
+        self.df = pd.read_csv(csv_path)
+        self.transform = transform
+        # FER2013 uses labels [0-6] in the same order as our class list
+        self.label_map = label_map or {i: i for i in range(7)}
+
+    def __len__(self):
+        return len(self.df)
+
+    def __getitem__(self, idx):
+        label = int(self.df.iloc[idx, 0])
+        pixels = self.df.iloc[idx, 1]
+        img = np.fromstring(pixels, dtype=np.uint8, sep=' ').reshape(48, 48)
+        img = np.stack([img] * 3, axis=-1)
+        img = Image.fromarray(img)
+        if self.transform:
+            img = self.transform(img)
+        label = self.label_map[label]
+        return img, label
+
+
+def get_dataloaders(data_dir, batch_size=64):
+    transform = transforms.Compose([
+        transforms.Resize((224, 224)),
+        transforms.RandomHorizontalFlip(),
+        transforms.RandomRotation(10),
+        transforms.ColorJitter(brightness=0.2, contrast=0.2, saturation=0.2),
+        transforms.ToTensor(),
+        transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+    ])
+    train_ds = FER2013Dataset(os.path.join(data_dir, 'train.csv'), transform=transform)
+    val_ds = FER2013Dataset(os.path.join(data_dir, 'val.csv'), transform=transform)
+    train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True, num_workers=2)
+    val_loader = DataLoader(val_ds, batch_size=batch_size, shuffle=False, num_workers=2)
+    return train_loader, val_loader
+
+
+def train(data_dir='fer2013', weight_path='weights/emotion_vit.pth', epochs=30, batch_size=64, lr=1e-3, patience=3):
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    train_loader, val_loader = get_dataloaders(data_dir, batch_size)
+    model = create_model('mobilevit_xxs', pretrained=True, num_classes=7)
+    model.to(device)
+    criterion = torch.nn.CrossEntropyLoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode='min', factor=0.5, patience=1, verbose=True)
+    best_loss = float('inf')
+    no_improve = 0
+    train_losses, val_losses = [], []
+    train_accs, val_accs = [] , []
+    for epoch in range(epochs):
+        model.train()
+        epoch_loss = 0.0
+        correct = 0
+        total = 0
+        train_iter = tqdm(train_loader, desc=f'Epoch {epoch + 1}/{epochs}', leave=False)
+        for images, labels in train_iter:
+            images, labels = images.to(device), labels.to(device)
+            optimizer.zero_grad()
+            outputs = model(images)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+            train_iter.set_postfix({'loss': loss.item()})
+            epoch_loss += loss.item() * images.size(0)
+            _, preds = torch.max(outputs, 1)
+            correct += (preds == labels).sum().item()
+            total += labels.size(0)
+        train_loss = epoch_loss / total if total > 0 else 0.0
+        train_acc = 100.0 * correct / total if total > 0 else 0.0
+        train_losses.append(train_loss)
+        train_accs.append(train_acc)
+
+        model.eval()
+        correct = 0
+        total = 0
+        running_loss = 0.0
+        val_iter = tqdm(val_loader, desc='Validating', leave=False)
+        with torch.no_grad():
+            for images, labels in val_iter:
+                images, labels = images.to(device), labels.to(device)
+                outputs = model(images)
+                loss = criterion(outputs, labels)
+                running_loss += loss.item() * images.size(0)
+                _, preds = torch.max(outputs, 1)
+                correct += (preds == labels).sum().item()
+                total += labels.size(0)
+        val_loss = running_loss / total if total > 0 else 0.0
+        val_acc = 100.0 * correct / total if total > 0 else 0.0
+        val_losses.append(val_loss)
+        val_accs.append(val_acc)
+        print(f'Epoch {epoch+1}/{epochs} - val loss: {val_loss:.4f} - acc: {val_acc:.2f}%')
+        scheduler.step(val_loss)
+
+        if val_loss < best_loss:
+            best_loss = val_loss
+            no_improve = 0
+            os.makedirs(os.path.dirname(weight_path), exist_ok=True)
+            torch.save(model.state_dict(), weight_path)
+        else:
+            no_improve += 1
+            if no_improve >= patience:
+                print('Early stopping')
+                break
+    if not os.path.exists(weight_path):
+        os.makedirs(os.path.dirname(weight_path), exist_ok=True)
+        torch.save(model.state_dict(), weight_path)
+    print(f'Saved best model to {weight_path}')
+
+    # plot training curves
+    epochs_range = range(1, len(train_losses) + 1)
+    plt.figure()
+    plt.plot(epochs_range, train_losses, label='train')
+    plt.plot(epochs_range, val_losses, label='val')
+    plt.xlabel('Epoch')
+    plt.ylabel('Loss')
+    plt.title('Training vs Validation Loss')
+    plt.legend()
+
+    plt.figure()
+    plt.plot(epochs_range, train_accs, label='train')
+    plt.plot(epochs_range, val_accs, label='val')
+    plt.xlabel('Epoch')
+    plt.ylabel('Accuracy (%)')
+    plt.title('Training vs Validation Accuracy')
+    plt.legend()
+    plt.show()
+
+
+if __name__ == '__main__':
+    train()


### PR DESCRIPTION
## Summary
- use ImageNet pretrained weights if custom weights are absent
- smooth predictions across frames to reduce flicker
- fix FER2013 label mapping and augment with random flips
- visualize training progress by plotting loss and accuracy
- update README with matplotlib dependency and plotting instructions
- train for up to 30 epochs with early stopping and additional augmentations

## Testing
- `python -m py_compile app.py face_detector.py emotion_recognizer.py model.py train.py`

------
https://chatgpt.com/codex/tasks/task_e_684ce8977d7883269ca9e23440615fb1