### PR TITLE
Add video recognition feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ To run emotion recognition on an arbitrary image instead of the webcam, use
 python predict_image.py path/to/image.jpg
 ```
 
+To run emotion recognition on a video file instead of the webcam, use
+`predict_video.py`:
+
+```bash
+python predict_video.py path/to/video.mp4
+```
+
+Press `q` to quit the application.
+
 Pretrained weights greatly improve recognition accuracy. Download a MobileViT emotion recognition checkpoint and place it at `weights/emotion_vit.pth`. If the file is missing, the model will start from ImageNet pretrained weights, which work reasonably but are less accurate for emotion recognition.
 
 

--- a/predict_video.py
+++ b/predict_video.py
@@ -1,0 +1,46 @@
+import argparse
+import cv2
+from face_detector import FaceDetector
+from emotion_recognizer import EmotionRecognizer
+
+
+def recognize_video(video_path):
+    """Run emotion recognition on a video file and display results."""
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        raise FileNotFoundError(f"Failed to open video: {video_path}")
+
+    detector = FaceDetector()
+    # Use the same smoothing window as the realtime demo
+    recognizer = EmotionRecognizer(smooth_window=5)
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        faces = detector.detect(frame)
+        for (x, y, w, h) in faces:
+            face_img = frame[y:y+h, x:x+w]
+            label, score = recognizer.predict(face_img)
+            cv2.rectangle(frame, (x, y), (x+w, y+h), (0, 255, 0), 2)
+            text = f"{label} {score:.2f}"
+            cv2.putText(frame, text, (x, y-10), cv2.FONT_HERSHEY_SIMPLEX, 0.9,
+                        (255, 0, 0), 2)
+        cv2.imshow('Emotion Recognition', frame)
+        if cv2.waitKey(1) & 0xFF == ord('q'):
+            break
+
+    cap.release()
+    cv2.destroyAllWindows()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run emotion recognition on a video file")
+    parser.add_argument("video", help="Path to an mp4 video")
+    args = parser.parse_args()
+    recognize_video(args.video)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `predict_video.py` to run emotion recognition on mp4 videos
- document how to use the new script in README

## Testing
- `python -m py_compile app.py emotion_recognizer.py face_detector.py predict_image.py predict_video.py train.py evaluate.py model.py`

------
https://chatgpt.com/codex/tasks/task_e_687640e9dd10832683ed5c4e2f01f37b