### PR TITLE
Improve training with larger model and data aug

### DIFF
--- a/model.py
+++ b/model.py
@@ -10,7 +10,7 @@ def load_model(weight_path="weights/emotion_vit.pth", device="cpu"):
 
     # Start from ImageNet pretrained weights for better accuracy when custom
     # emotion weights are unavailable.
-    model = create_model("mobilevit_xxs", pretrained=True, num_classes=7)
+    model = create_model("mobilevit_xs", pretrained=True, num_classes=7, drop_rate=0.2)
 
     if weight_path and os.path.exists(weight_path):
         state = torch.load(weight_path, map_location=device)

--- a/train.py
+++ b/train.py
@@ -35,16 +35,26 @@ class FER2013Dataset(Dataset):
 
 
 def get_dataloaders(data_dir, batch_size=64):
-    transform = transforms.Compose([
-        transforms.Resize((224, 224)),
+    """Return train/val loaders with stronger augmentation on the train split."""
+
+    train_transform = transforms.Compose([
+        transforms.RandomResizedCrop(224, scale=(0.8, 1.0)),
         transforms.RandomHorizontalFlip(),
-        transforms.RandomRotation(10),
-        transforms.ColorJitter(brightness=0.2, contrast=0.2, saturation=0.2),
+        transforms.RandomRotation(20),
+        transforms.ColorJitter(brightness=0.4, contrast=0.4, saturation=0.4),
+        transforms.ToTensor(),
+        transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
+        transforms.RandomErasing(p=0.5),
+    ])
+
+    val_transform = transforms.Compose([
+        transforms.Resize((224, 224)),
         transforms.ToTensor(),
         transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
     ])
-    train_ds = FER2013Dataset(os.path.join(data_dir, 'train.csv'), transform=transform)
-    val_ds = FER2013Dataset(os.path.join(data_dir, 'val.csv'), transform=transform)
+
+    train_ds = FER2013Dataset(os.path.join(data_dir, 'train.csv'), transform=train_transform)
+    val_ds = FER2013Dataset(os.path.join(data_dir, 'val.csv'), transform=val_transform)
     train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True, num_workers=2)
     val_loader = DataLoader(val_ds, batch_size=batch_size, shuffle=False, num_workers=2)
     return train_loader, val_loader
@@ -53,10 +63,10 @@ def get_dataloaders(data_dir, batch_size=64):
 def train(data_dir='fer2013', weight_path='weights/emotion_vit.pth', epochs=50, batch_size=64, lr=1e-3, patience=3):
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     train_loader, val_loader = get_dataloaders(data_dir, batch_size)
-    model = create_model('mobilevit_xxs', pretrained=True, num_classes=7)
+    model = create_model('mobilevit_xs', pretrained=True, num_classes=7, drop_rate=0.2)
     model.to(device)
     criterion = torch.nn.CrossEntropyLoss()
-    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr, weight_decay=1e-4)
     scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode='min', factor=0.5, patience=1)
     best_loss = float('inf')
     no_improve = 0


### PR DESCRIPTION
## Summary
- switch to the larger **mobilevit_xs** backbone
- expand data augmentation with `RandomResizedCrop` and `RandomErasing`
- add dropout and weight decay for better regularization

## Testing
- `python -m py_compile train.py model.py`

------
https://chatgpt.com/codex/tasks/task_e_687e185158ac8326a0f0834ea1832ce8